### PR TITLE
Resize the data types to 32 bits so that we can display values larger than 65536

### DIFF
--- a/TM1637Display.cpp
+++ b/TM1637Display.cpp
@@ -123,12 +123,12 @@ void TM1637Display::clear()
 	setSegments(data);
 }
 
-void TM1637Display::showNumberDec(int num, bool leading_zero, uint8_t length, uint8_t pos)
+void TM1637Display::showNumberDec(int32_t num, bool leading_zero, uint8_t length, uint8_t pos)
 {
   showNumberDecEx(num, 0, leading_zero, length, pos);
 }
 
-void TM1637Display::showNumberDecEx(int num, uint8_t dots, bool leading_zero,
+void TM1637Display::showNumberDecEx(int32_t num, uint8_t dots, bool leading_zero,
                                     uint8_t length, uint8_t pos)
 {
   showNumberBaseEx(num < 0? -10 : 10, num < 0? -num : num, dots, leading_zero, length, pos);
@@ -140,7 +140,7 @@ void TM1637Display::showNumberHexEx(uint16_t num, uint8_t dots, bool leading_zer
   showNumberBaseEx(16, num, dots, leading_zero, length, pos);
 }
 
-void TM1637Display::showNumberBaseEx(int8_t base, uint16_t num, uint8_t dots, bool leading_zero,
+void TM1637Display::showNumberBaseEx(int8_t base, uint32_t num, uint8_t dots, bool leading_zero,
                                     uint8_t length, uint8_t pos)
 {
 	if( length == 255 ) {

--- a/TM1637Display.h
+++ b/TM1637Display.h
@@ -87,7 +87,7 @@ public:
   //!        fits to the number of digits requested (for example, if two digits are to be displayed,
   //!        the number must be between 0 to 99)
   //! @param pos The position of the most significant digit (0 - leftmost, 3 - rightmost)
-  void showNumberDec(int num, bool leading_zero = false, uint8_t length = 255, uint8_t pos = 0);
+  void showNumberDec(int32_t num, bool leading_zero = false, uint8_t length = 255, uint8_t pos = 0);
 
   //! Display a decimal number, with dot control
   //!
@@ -112,7 +112,7 @@ public:
   //!        fits to the number of digits requested (for example, if two digits are to be displayed,
   //!        the number must be between 0 to 99)
   //! @param pos The position of the most significant digit (0 - leftmost, 3 - rightmost)
-  void showNumberDecEx(int num, uint8_t dots = 0, bool leading_zero = false, uint8_t length = 255, uint8_t pos = 0);
+  void showNumberDecEx(int32_t num, uint8_t dots = 0, bool leading_zero = false, uint8_t length = 255, uint8_t pos = 0);
 
   //! Display a hexadecimal number, with dot control
   //!
@@ -161,7 +161,7 @@ protected:
 
    void showDots(uint8_t dots, uint8_t* digits);
    
-   void showNumberBaseEx(int8_t base, uint16_t num, uint8_t dots = 0, bool leading_zero = false, uint8_t length = 255, uint8_t pos = 0);
+   void showNumberBaseEx(int8_t base, uint32_t num, uint8_t dots = 0, bool leading_zero = false, uint8_t length = 255, uint8_t pos = 0);
 
 
 private:


### PR DESCRIPTION
I really like this library and it works pretty well, but unfortunately it can only display values up to 65536 out of the box due to using 16 bit unsigned integers internally. This made sense in the original version, which was only really made for 4 digits, but it doesn't suffice for 5 or 6 digits, so I quickly just switched the parameter types for their 32 bit counterparts and voila, we can now display larger values.